### PR TITLE
Update OSCAR links and names

### DIFF
--- a/index.txt
+++ b/index.txt
@@ -42,8 +42,8 @@ Although FLINT itself is written in C, bindings are available for various genera
 <a href="https://hackage.haskell.org/package/Flint2">Haskell</a> and <a href="https://github.com/flintlib/flintxx">C++</a>.
 Several computer algebra systems also rely on FLINT as a back-end library,
 including
-<a href="https://sagemath.org">SageMath</a>,
-<a href="https://oscar.computeralgebra.de/">Oscar</a>,
+<a href="https://www.sagemath.org">SageMath</a>,
+<a href="https://www.oscar-system.org/">OSCAR</a>,
 <a href="https://www.singular.uni-kl.de/">Singular</a>,
 <a href="http://www2.macaulay2.com/Macaulay2/">Macaulay2</a>,
 <a href="https://www.maplesoft.com/products/Maple/">Maple</a>

--- a/links.txt
+++ b/links.txt
@@ -12,7 +12,7 @@
 <li><a href="https://www.singular.uni-kl.de">Singular</a> uses FLINT internally</a></li>
 <li><a href="http://www2.macaulay2.com/Macaulay2/">Macaulay2</a> uses FLINT internally</a></li>
 <li><a href="http://www.hcrypt.com/scarab-library/">Scarab library</a> - an implementation of fully homomorphic encryption using FLINT.</li>
-<li><a href="https://oscar.computeralgebra.de/">OSCAR</a> - Computer Algebra System (TRR-195)</li>
+<li><a href="https://www.oscar-system.org/">OSCAR</a> - Computer Algebra System</li>
 <li><a
 href="https://research.coe.drexel.edu/ece/aspitrg/chmlib-readme.txt">chmlib</a> - Projection of polyhedral cones</li>
 <li><a href="https://arblib.org/">Arb</a> - Real and complex ball arithmetic (merged with FLINT 3.0)</li>


### PR DESCRIPTION
Also, sagemath.org redirects to the 'official' URL www.sagemath.org
